### PR TITLE
feat: Integrar migraciones, dim_tiempo y vistas analíticas en ETL 

### DIFF
--- a/src/database_views.py
+++ b/src/database_views.py
@@ -1,0 +1,135 @@
+"""Definición de vistas analíticas sobre el data warehouse SQLite."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+logger = logging.getLogger(__name__)
+
+
+def create_analytical_views(conn: sqlite3.Connection) -> None:
+    """
+    Crea o recrea las vistas analíticas principales de forma idempotente.
+
+    Vistas creadas:
+        - v_affordability_quarterly
+        - v_precios_evolucion_anual
+        - v_demografia_resumen
+        - v_gentrificacion_tendencias
+
+    Args:
+        conn: Conexión SQLite activa.
+    """
+    logger.info("Creando vistas analíticas si no existen")
+
+    scripts = [
+        # Vista de affordability trimestral basada en fact_housing_master
+        """
+        DROP VIEW IF EXISTS v_affordability_quarterly;
+        CREATE VIEW v_affordability_quarterly AS
+        SELECT 
+            fhm.barrio_id,
+            db.barrio_nombre,
+            fhm.year,
+            fhm.quarter,
+            fhm.preu_venda_m2,
+            fhm.renta_annual,
+            fhm.price_to_income_ratio,
+            fhm.rent_burden_pct,
+            fhm.affordability_index,
+            CASE 
+                WHEN fhm.affordability_index < 3 THEN 'Muy Baja'
+                WHEN fhm.affordability_index < 5 THEN 'Baja'
+                WHEN fhm.affordability_index < 7 THEN 'Media'
+                WHEN fhm.affordability_index < 9 THEN 'Alta'
+                ELSE 'Muy Alta'
+            END AS categoria_affordability
+        FROM fact_housing_master fhm
+        JOIN dim_barrios db ON fhm.barrio_id = db.barrio_id
+        WHERE fhm.renta_annual IS NOT NULL
+          AND fhm.preu_venda_m2 IS NOT NULL;
+        """,
+        # Evolución anual de precios por barrio
+        """
+        DROP VIEW IF EXISTS v_precios_evolucion_anual;
+        CREATE VIEW v_precios_evolucion_anual AS
+        SELECT 
+            barrio_id,
+            anio,
+            AVG(precio_m2_venta) AS precio_m2_venta_promedio,
+            AVG(precio_mes_alquiler) AS precio_mes_alquiler_promedio,
+            COUNT(*) AS num_registros
+        FROM fact_precios
+        WHERE precio_m2_venta IS NOT NULL 
+           OR precio_mes_alquiler IS NOT NULL
+        GROUP BY barrio_id, anio
+        ORDER BY barrio_id, anio;
+        """,
+        # Resumen demográfico por barrio y año
+        """
+        DROP VIEW IF EXISTS v_demografia_resumen;
+        CREATE VIEW v_demografia_resumen AS
+        SELECT 
+            d.barrio_id,
+            db.barrio_nombre,
+            d.anio,
+            d.poblacion_total,
+            d.poblacion_hombres,
+            d.poblacion_mujeres,
+            d.hogares_totales,
+            d.edad_media,
+            d.porc_inmigracion,
+            d.densidad_hab_km2,
+            d.pct_mayores_65,
+            d.pct_menores_15,
+            d.indice_envejecimiento
+        FROM fact_demografia d
+        JOIN dim_barrios db ON d.barrio_id = db.barrio_id
+        ORDER BY d.barrio_id, d.anio;
+        """,
+        # Tendencias de gentrificación (2015 vs 2024)
+        """
+        DROP VIEW IF EXISTS v_gentrificacion_tendencias;
+        CREATE VIEW v_gentrificacion_tendencias AS
+        SELECT 
+            db.barrio_id,
+            db.barrio_nombre,
+            p15.precio_m2_venta AS precio_2015,
+            p24.precio_m2_venta AS precio_2024,
+            ((p24.precio_m2_venta - p15.precio_m2_venta) / p15.precio_m2_venta * 100.0)
+                AS pct_cambio_precio,
+            r15.renta_mediana AS renta_2015,
+            r24.renta_mediana AS renta_2024,
+            ((r24.renta_mediana - r15.renta_mediana) / r15.renta_mediana * 100.0)
+                AS pct_cambio_renta,
+            d15.poblacion_total AS poblacion_2015,
+            d24.poblacion_total AS poblacion_2024
+        FROM dim_barrios db
+        LEFT JOIN fact_precios p15 
+               ON db.barrio_id = p15.barrio_id AND p15.anio = 2015
+        LEFT JOIN fact_precios p24 
+               ON db.barrio_id = p24.barrio_id AND p24.anio = 2024
+        LEFT JOIN fact_renta r15 
+               ON db.barrio_id = r15.barrio_id AND r15.anio = 2015
+        LEFT JOIN fact_renta r24 
+               ON db.barrio_id = r24.barrio_id AND r24.anio = 2024
+        LEFT JOIN fact_demografia d15 
+               ON db.barrio_id = d15.barrio_id AND d15.anio = 2015
+        LEFT JOIN fact_demografia d24 
+               ON db.barrio_id = d24.barrio_id AND d24.anio = 2024
+        WHERE p15.precio_m2_venta IS NOT NULL 
+          AND p24.precio_m2_venta IS NOT NULL;
+        """,
+    ]
+
+    with conn:
+        for script in scripts:
+            conn.executescript(script)
+
+    logger.info("Vistas analíticas creadas/actualizadas correctamente")
+
+
+__all__ = ["create_analytical_views"]
+
+

--- a/src/etl/migrations.py
+++ b/src/etl/migrations.py
@@ -1,0 +1,274 @@
+"""Funciones de migración e infraestructura ETL (dim_barrios, códigos INE, etc.)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_centroid(geometry_json: str) -> Optional[Tuple[float, float]]:
+    """
+    Calcula el centroide de una geometría GeoJSON simple.
+
+    Args:
+        geometry_json: Cadena JSON con una geometría GeoJSON (Polygon o MultiPolygon).
+
+    Returns:
+        Tupla (latitud, longitud) del centroide o ``None`` si no se puede calcular.
+    """
+    if not geometry_json:
+        return None
+
+    try:
+        geom = json.loads(geometry_json)
+    except json.JSONDecodeError as exc:
+        logger.warning("Error decodificando GeoJSON para centroide: %s", exc)
+        return None
+
+    geom_type = geom.get("type")
+    if geom_type == "Polygon":
+        coords = geom.get("coordinates", [])
+        if not coords:
+            return None
+        ring = coords[0]
+    elif geom_type == "MultiPolygon":
+        coords = geom.get("coordinates", [])
+        if not coords or not coords[0]:
+            return None
+        ring = coords[0][0]
+    else:
+        logger.warning("Tipo de geometría no soportado para centroide: %s", geom_type)
+        return None
+
+    if not isinstance(ring, list) or len(ring) < 3:
+        return None
+
+    try:
+        lons = [float(point[0]) for point in ring]
+        lats = [float(point[1]) for point in ring]
+    except (TypeError, ValueError) as exc:
+        logger.warning("Coordenadas inválidas en GeoJSON: %s", exc)
+        return None
+
+    centroid_lon = sum(lons) / len(lons)
+    centroid_lat = sum(lats) / len(lats)
+    return centroid_lat, centroid_lon
+
+
+def _calculate_polygon_area_deg2(coords: Iterable[Iterable[float]]) -> Optional[float]:
+    """Calcula el área de un polígono en grados² usando la fórmula de Shoelace."""
+    points: List[Tuple[float, float]] = []
+    for point in coords:
+        try:
+            lon = float(point[0])
+            lat = float(point[1])
+        except (TypeError, ValueError, IndexError):
+            continue
+        points.append((lon, lat))
+
+    n = len(points)
+    if n < 3:
+        return None
+
+    area = 0.0
+    for i in range(n):
+        j = (i + 1) % n
+        area += points[i][0] * points[j][1]
+        area -= points[j][0] * points[i][1]
+
+    return abs(area) / 2.0
+
+
+def calculate_area_km2(geometry_json: str) -> Optional[float]:
+    """
+    Calcula el área aproximada en km² de una geometría GeoJSON.
+
+    Returns:
+        Área aproximada en km² o ``None`` si no se puede calcular.
+    """
+    if not geometry_json:
+        return None
+
+    try:
+        geom = json.loads(geometry_json)
+    except json.JSONDecodeError as exc:
+        logger.warning("Error decodificando GeoJSON para área: %s", exc)
+        return None
+
+    geom_type = geom.get("type")
+    if geom_type == "Polygon":
+        coords = geom.get("coordinates", [])
+        if not coords:
+            return None
+        ring = coords[0]
+        area_deg2 = _calculate_polygon_area_deg2(ring)
+    elif geom_type == "MultiPolygon":
+        total_area_deg2 = 0.0
+        for polygon in geom.get("coordinates", []):
+            if not polygon:
+                continue
+            ring = polygon[0]
+            partial = _calculate_polygon_area_deg2(ring)
+            if partial is not None:
+                total_area_deg2 += partial
+        area_deg2 = total_area_deg2 if total_area_deg2 > 0 else None
+    else:
+        logger.warning("Tipo de geometría no soportado para área: %s", geom_type)
+        return None
+
+    if area_deg2 is None:
+        return None
+
+    import math
+
+    try:
+        coords_sample = geom.get("coordinates", [])
+        sample_ring = coords_sample[0] if geom_type == "Polygon" else coords_sample[0][0]
+        lats = [float(p[1]) for p in sample_ring]
+        avg_lat = sum(lats) / len(lats)
+    except Exception:  # noqa: BLE001
+        avg_lat = 41.4
+
+    lat_factor_km = 111.0
+    lon_factor_km = 111.0 * abs(math.cos(math.radians(avg_lat)))
+
+    area_km2 = area_deg2 * lat_factor_km * lon_factor_km
+    return area_km2
+
+
+def get_ine_codes(mapping_path: Optional[Path] = None) -> Dict[int, str]:
+    """
+    Carga el mapeo de ``barrio_id`` a código INE desde un archivo JSON.
+
+    Devuelve un diccionario vacío si el archivo no existe o no es válido.
+    """
+    if mapping_path is None:
+        project_root = Path(__file__).resolve().parents[2]
+        mapping_path = project_root / "data" / "reference" / "barrio_ine_mapping.json"
+
+    if not mapping_path.exists():
+        logger.warning("Archivo de mapeo INE no encontrado: %s", mapping_path)
+        return {}
+
+    try:
+        raw = json.loads(mapping_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.error("Error al decodificar barrio_ine_mapping.json: %s", exc)
+        return {}
+
+    mapping: Dict[int, str] = {}
+    for key, value in raw.items():
+        try:
+            barrio_id = int(key)
+            code = str(value)
+        except (TypeError, ValueError):
+            logger.warning("Entrada inválida en mapeo INE: %r -> %r", key, value)
+            continue
+
+        if not code.startswith("08019") or len(code) != 8:
+            logger.warning("Código INE con formato inesperado para barrio %s: %s", barrio_id, code)
+        mapping[barrio_id] = code
+
+    logger.info("Mapeo INE cargado: %s barrios", len(mapping))
+    return mapping
+
+
+def migrate_dim_barrios_if_needed(conn: sqlite3.Connection) -> None:
+    """
+    Ejecuta migración idempotente sobre ``dim_barrios`` para añadir campos derivados.
+    """
+    logger.info("Aplicando migración idempotente de dim_barrios (centroides, áreas, códigos INE)")
+
+    try:
+        cursor = conn.execute("PRAGMA table_info(dim_barrios)")
+        existing_columns = {row[1] for row in cursor.fetchall()}
+    except sqlite3.Error as exc:
+        logger.warning("No se pudo inspeccionar dim_barrios: %s", exc)
+        return
+
+    new_columns = {
+        "codigo_ine": "TEXT",
+        "centroide_lat": "REAL",
+        "centroide_lon": "REAL",
+        "area_km2": "REAL",
+    }
+
+    try:
+        for col_name, col_type in new_columns.items():
+            if col_name not in existing_columns:
+                logger.info("Añadiendo columna %s a dim_barrios", col_name)
+                conn.execute(f"ALTER TABLE dim_barrios ADD COLUMN {col_name} {col_type}")
+        conn.commit()
+    except sqlite3.Error as exc:
+        logger.warning("Error añadiendo columnas a dim_barrios: %s", exc)
+        return
+
+    try:
+        cursor = conn.execute(
+            """
+            SELECT barrio_id, geometry_json, codigo_ine
+            FROM dim_barrios
+            """
+        )
+        rows = cursor.fetchall()
+    except sqlite3.Error as exc:
+        logger.warning("No se pudo leer dim_barrios para migración: %s", exc)
+        return
+
+    ine_codes = get_ine_codes()
+
+    updated = 0
+    for barrio_id, geometry_json, codigo_ine in rows:
+        if geometry_json is None and codigo_ine is not None:
+            continue
+
+        centroide_lat: Optional[float] = None
+        centroide_lon: Optional[float] = None
+        area_km2: Optional[float] = None
+
+        if geometry_json:
+            centroid = calculate_centroid(geometry_json)
+            if centroid:
+                centroide_lat, centroide_lon = centroid
+            area_km2 = calculate_area_km2(geometry_json)
+
+        final_codigo_ine = codigo_ine or ine_codes.get(barrio_id)
+
+        try:
+            conn.execute(
+                """
+                UPDATE dim_barrios
+                SET centroide_lat = COALESCE(centroide_lat, ?),
+                    centroide_lon = COALESCE(centroide_lon, ?),
+                    area_km2 = COALESCE(area_km2, ?),
+                    codigo_ine = COALESCE(codigo_ine, ?)
+                WHERE barrio_id = ?
+                """,
+                (centroide_lat, centroide_lon, area_km2, final_codigo_ine, barrio_id),
+            )
+            if centroide_lat is not None or area_km2 is not None or final_codigo_ine:
+                updated += 1
+        except sqlite3.Error as exc:
+            logger.warning("Error actualizando barrio %s en dim_barrios: %s", barrio_id, exc)
+
+    try:
+        conn.commit()
+    except sqlite3.Error as exc:
+        logger.warning("Error haciendo commit de migración dim_barrios: %s", exc)
+        return
+
+    logger.info("Migración dim_barrios completada. Barrios actualizados: %s", updated)
+
+
+__all__ = [
+    "calculate_centroid",
+    "calculate_area_km2",
+    "get_ine_codes",
+    "migrate_dim_barrios_if_needed",
+]
+

--- a/tests/test_database_views.py
+++ b/tests/test_database_views.py
@@ -1,0 +1,216 @@
+"""Tests para las vistas analíticas definidas en src.database_views."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from src.database_setup import create_connection, create_database_schema
+from src.database_views import create_analytical_views
+
+
+def _get_conn(tmpdir: str) -> sqlite3.Connection:
+    db_path = Path(tmpdir) / "test_database_views.db"
+    return create_connection(db_path)
+
+
+def test_create_analytical_views_basic() -> None:
+    """Verifica que las vistas principales se crean sin errores."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        conn = _get_conn(tmpdir)
+        try:
+            create_database_schema(conn)
+            create_analytical_views(conn)
+
+            cursor = conn.execute(
+                """
+                SELECT name FROM sqlite_master
+                WHERE type = 'view'
+                ORDER BY name
+                """,
+            )
+            view_names = {row[0] for row in cursor.fetchall()}
+
+            assert "v_affordability_quarterly" in view_names
+            assert "v_precios_evolucion_anual" in view_names
+            assert "v_demografia_resumen" in view_names
+            assert "v_gentrificacion_tendencias" in view_names
+        finally:
+            conn.close()
+
+
+def test_v_precios_evolucion_anual_returns_data() -> None:
+    """Verifica que v_precios_evolucion_anual agrega correctamente precios anuales."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        conn = _get_conn(tmpdir)
+        try:
+            create_database_schema(conn)
+
+            # Insertar dim_barrios para cumplir la FK
+            conn.execute(
+                """
+                INSERT INTO dim_barrios (
+                    barrio_id, barrio_nombre, barrio_nombre_normalizado,
+                    distrito_id, distrito_nombre, municipio, ambito,
+                    codi_districte, codi_barri, geometry_json,
+                    source_dataset, etl_created_at, etl_updated_at
+                ) VALUES (1, 'Test', 'test', 1, 'Distrito', 'Barcelona', 'barri',
+                          '01', '01', NULL, 'test', 'ts', 'ts')
+                """,
+            )
+
+            # Insertar datos mínimos en fact_precios
+            conn.execute(
+                """
+                INSERT INTO fact_precios (
+                    barrio_id, anio, periodo, trimestre,
+                    precio_m2_venta, precio_mes_alquiler,
+                    dataset_id, source, etl_loaded_at
+                ) VALUES (1, 2020, '2020', NULL, 3000.0, NULL, 'test', 'unit', 'ts')
+                """,
+            )
+            conn.commit()
+
+            create_analytical_views(conn)
+
+            cursor = conn.execute(
+                "SELECT barrio_id, anio, precio_m2_venta_promedio FROM v_precios_evolucion_anual",
+            )
+            row = cursor.fetchone()
+            assert row is not None
+            assert row[0] == 1
+            assert row[1] == 2020
+            assert row[2] == 3000.0
+        finally:
+            conn.close()
+
+
+def test_v_demografia_resumen_join_structure() -> None:
+    """Verifica que v_demografia_resumen realiza el join con dim_barrios correctamente."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        conn = _get_conn(tmpdir)
+        try:
+            create_database_schema(conn)
+
+            conn.execute(
+                """
+                INSERT INTO dim_barrios (
+                    barrio_id, barrio_nombre, barrio_nombre_normalizado,
+                    distrito_id, distrito_nombre, municipio, ambito,
+                    codi_districte, codi_barri, geometry_json,
+                    source_dataset, etl_created_at, etl_updated_at
+                ) VALUES (1, 'Test', 'test', 1, 'Distrito', 'Barcelona', 'barri',
+                          '01', '01', NULL, 'test', 'ts', 'ts')
+                """,
+            )
+            conn.execute(
+                """
+                INSERT INTO fact_demografia (
+                    barrio_id, anio, poblacion_total,
+                    poblacion_hombres, poblacion_mujeres,
+                    hogares_totales, edad_media, porc_inmigracion,
+                    densidad_hab_km2, pct_mayores_65, pct_menores_15,
+                    indice_envejecimiento, dataset_id, source, etl_loaded_at
+                ) VALUES (1, 2020, 1000, 480, 520, 400, 40.0, 10.0, 10000.0,
+                          12.5, 15.0, 0.83, 'test', 'unit', 'ts')
+                """,
+            )
+            conn.commit()
+
+            create_analytical_views(conn)
+
+            cursor = conn.execute(
+                """
+                SELECT barrio_id, barrio_nombre, anio, poblacion_total
+                FROM v_demografia_resumen
+                """,
+            )
+            row = cursor.fetchone()
+            assert row is not None
+            assert row[0] == 1
+            assert row[1] == "Test"
+            assert row[2] == 2020
+            assert row[3] == 1000
+        finally:
+            conn.close()
+
+
+def test_v_gentrificacion_tendencias_basic_signal() -> None:
+    """Verifica que v_gentrificacion_tendencias produce al menos una fila válida."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        conn = _get_conn(tmpdir)
+        try:
+            create_database_schema(conn)
+
+            conn.execute(
+                """
+                INSERT INTO dim_barrios (
+                    barrio_id, barrio_nombre, barrio_nombre_normalizado,
+                    distrito_id, distrito_nombre, municipio, ambito,
+                    codi_districte, codi_barri, geometry_json,
+                    source_dataset, etl_created_at, etl_updated_at
+                ) VALUES (1, 'Test', 'test', 1, 'Distrito', 'Barcelona', 'barri',
+                          '01', '01', NULL, 'test', 'ts', 'ts')
+                """,
+            )
+            conn.execute(
+                """
+                INSERT INTO fact_precios (
+                    barrio_id, anio, periodo, trimestre,
+                    precio_m2_venta, precio_mes_alquiler,
+                    dataset_id, source, etl_loaded_at
+                ) VALUES
+                    (1, 2015, '2015', NULL, 2000.0, NULL, 'test', 'unit', 'ts'),
+                    (1, 2024, '2024', NULL, 4000.0, NULL, 'test', 'unit', 'ts')
+                """,
+            )
+            conn.execute(
+                """
+                INSERT INTO fact_renta (
+                    barrio_id, anio, renta_euros, renta_promedio,
+                    renta_mediana, renta_min, renta_max,
+                    num_secciones, barrio_nombre_normalizado,
+                    dataset_id, source, etl_loaded_at
+                ) VALUES
+                    (1, 2015, 20000.0, 20000.0, 20000.0, 15000.0, 25000.0,
+                     10, 'test', 'test', 'unit', 'ts'),
+                    (1, 2024, 30000.0, 30000.0, 30000.0, 20000.0, 35000.0,
+                     10, 'test', 'test', 'unit', 'ts')
+                """,
+            )
+            conn.execute(
+                """
+                INSERT INTO fact_demografia (
+                    barrio_id, anio, poblacion_total,
+                    poblacion_hombres, poblacion_mujeres,
+                    hogares_totales, edad_media, porc_inmigracion,
+                    densidad_hab_km2, dataset_id, source, etl_loaded_at
+                ) VALUES
+                    (1, 2015, 1000, 480, 520, 400, 40.0, 10.0, 10000.0,
+                     'test', 'unit', 'ts'),
+                    (1, 2024, 1100, 520, 580, 420, 41.0, 11.0, 10500.0,
+                     'test', 'unit', 'ts')
+                """,
+            )
+            conn.commit()
+
+            create_analytical_views(conn)
+
+            cursor = conn.execute(
+                """
+                SELECT barrio_id, precio_2015, precio_2024, pct_cambio_precio
+                FROM v_gentrificacion_tendencias
+                """,
+            )
+            row = cursor.fetchone()
+            assert row is not None
+            assert row[0] == 1
+            assert row[1] == 2000.0
+            assert row[2] == 4000.0
+            # Cambio del 100%
+            assert round(row[3], 1) == 100.0
+        finally:
+            conn.close()
+
+

--- a/tests/test_dim_barrios_migration.py
+++ b/tests/test_dim_barrios_migration.py
@@ -1,0 +1,124 @@
+"""Tests para migraciones de dim_barrios (centroides, área, códigos INE)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from src.database_setup import create_connection, create_database_schema
+from src.etl.migrations import (
+    calculate_area_km2,
+    calculate_centroid,
+    get_ine_codes,
+    migrate_dim_barrios_if_needed,
+)
+
+
+def test_calculate_centroid_polygon() -> None:
+    """Verifica que calculate_centroid calcula un centroide razonable para un polígono."""
+    # Polígono rectangular aproximado en Barcelona
+    polygon = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [2.15, 41.39],
+                [2.16, 41.39],
+                [2.16, 41.40],
+                [2.15, 41.40],
+                [2.15, 41.39],
+            ],
+        ],
+    }
+    centroid = calculate_centroid(json.dumps(polygon))
+    assert centroid is not None
+    lat, lon = centroid
+    # Rango aproximado de Barcelona
+    assert 41.3 < lat < 41.5
+    assert 2.1 < lon < 2.2
+
+
+def test_calculate_area_km2_polygon() -> None:
+    """Verifica que calculate_area_km2 devuelve un área positiva y razonable."""
+    polygon = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [2.15, 41.39],
+                [2.16, 41.39],
+                [2.16, 41.40],
+                [2.15, 41.40],
+                [2.15, 41.39],
+            ],
+        ],
+    }
+    area = calculate_area_km2(json.dumps(polygon))
+    assert area is not None
+    # Un rectángulo de ~0.01 x 0.01 grados debería dar un área pequeña pero >0
+    assert 0.01 <= area <= 5.0
+
+
+def test_get_ine_codes_missing_file_returns_empty_dict() -> None:
+    """Verifica que get_ine_codes devuelve dict vacío si el archivo no existe."""
+    mapping = get_ine_codes(mapping_path=Path("no_existe_ine_mapping.json"))
+    assert mapping == {}
+
+
+def test_migrate_dim_barrios_if_needed_updates_columns() -> None:
+    """Verifica que la migración añade columnas y calcula centroides/área."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test_dim_barrios_migration.db"
+        conn = create_connection(db_path)
+        try:
+            create_database_schema(conn)
+
+            # Insertar un barrio con geometría simple
+            polygon = {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [2.15, 41.39],
+                        [2.16, 41.39],
+                        [2.16, 41.40],
+                        [2.15, 41.40],
+                        [2.15, 41.39],
+                    ],
+                ],
+            }
+            conn.execute(
+                """
+                INSERT INTO dim_barrios (
+                    barrio_id, barrio_nombre, barrio_nombre_normalizado,
+                    distrito_id, distrito_nombre, municipio, ambito,
+                    codi_districte, codi_barri, geometry_json,
+                    source_dataset, etl_created_at, etl_updated_at
+                ) VALUES (1, 'Test', 'test', 1, 'Distrito', 'Barcelona', 'barri',
+                          '01', '01', ?, 'test', 'ts', 'ts')
+                """,
+                (json.dumps(polygon),),
+            )
+            conn.commit()
+
+            migrate_dim_barrios_if_needed(conn)
+
+            cursor = conn.execute(
+                """
+                SELECT centroide_lat, centroide_lon, area_km2
+                FROM dim_barrios
+                WHERE barrio_id = 1
+                """,
+            )
+            row = cursor.fetchone()
+            assert row is not None
+            centroide_lat, centroide_lon, area_km2 = row
+            assert centroide_lat is not None
+            assert centroide_lon is not None
+            assert area_km2 is not None
+            assert 41.3 < centroide_lat < 41.5
+            assert 2.1 < centroide_lon < 2.2
+            assert 0.01 <= area_km2 <= 5.0
+        finally:
+            conn.close()
+
+

--- a/tests/test_dim_tiempo.py
+++ b/tests/test_dim_tiempo.py
@@ -1,0 +1,57 @@
+"""Tests para la dimensión temporal dim_tiempo."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from src.database_setup import create_connection, create_database_schema
+
+
+def _get_conn(tmpdir: str) -> sqlite3.Connection:
+    db_path = Path(tmpdir) / "test_dim_tiempo.db"
+    return create_connection(db_path)
+
+
+def test_dim_tiempo_created_and_populated() -> None:
+    """Verifica que dim_tiempo se crea y se puebla para 2015-2024."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        conn = _get_conn(tmpdir)
+        try:
+            create_database_schema(conn)
+
+            cursor = conn.execute(
+                """
+                SELECT MIN(anio), MAX(anio), COUNT(*)
+                FROM dim_tiempo
+                """,
+            )
+            min_year, max_year, total = cursor.fetchone()
+
+            assert min_year <= 2015
+            assert max_year >= 2024
+            # 10 años * (1 anual + 4 trimestrales) = 50 filas mínimas esperadas
+            assert total >= 50
+        finally:
+            conn.close()
+
+
+def test_dim_tiempo_idempotent() -> None:
+    """Verifica que llamar a create_database_schema dos veces no duplica registros."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        conn = _get_conn(tmpdir)
+        try:
+            create_database_schema(conn)
+            cursor = conn.execute("SELECT COUNT(*) FROM dim_tiempo")
+            first_count = cursor.fetchone()[0]
+
+            create_database_schema(conn)
+            cursor = conn.execute("SELECT COUNT(*) FROM dim_tiempo")
+            second_count = cursor.fetchone()[0]
+
+            assert first_count == second_count
+        finally:
+            conn.close()
+
+


### PR DESCRIPTION
Este PR integra en el pipeline ETL las mejoras definidas en la Fase 1 para migraciones de `dim_barrios`, creación de `dim_tiempo` y vistas analíticas.

### Cambios principales

- **Módulo de migraciones (`src/etl/migrations.py`)**
  - Implementa `calculate_centroid()` y `calculate_area_km2()` para calcular centroides y áreas desde `geometry_json`.
  - Implementa `get_ine_codes()` leyendo `data/reference/barrio_ine_mapping.json` con validaciones básicas de formato `08019XXX`.
  - Implementa `migrate_dim_barrios_if_needed(conn)`:
    - Añade columnas `codigo_ine`, `centroide_lat`, `centroide_lon`, `area_km2` si no existen.
    - Calcula centroides y áreas solo cuando faltan.
    - Población de `codigo_ine` únicamente cuando está `NULL`.
    - Diseño idempotente (se puede ejecutar múltiples veces sin efectos adversos).

- **Esquema y migraciones de base de datos (`src/database_setup.py`)**
  - Extiende `fact_demografia` con:
    - `pct_mayores_65`, `pct_menores_15`, `indice_envejecimiento`.
  - Añade migración idempotente en `migrate_database_schema()` para crear estas columnas si faltan en BDs existentes.
  - Añade `ensure_dim_tiempo(conn)`:
    - Crea `dim_tiempo` con índices (`idx_dim_tiempo_periodo`, `idx_dim_tiempo_anio_trimestre`).
    - Población automática para 2015–2024 (anual + trimestral) de forma idempotente.
  - Llama a `ensure_dim_tiempo(conn)` desde `create_database_schema()` para garantizar que siempre exista.

- **Vistas analíticas (`src/database_views.py`)**
  - Nueva función `create_analytical_views(conn)` que crea/recrea de forma idempotente:
    - `v_affordability_quarterly`
    - `v_precios_evolucion_anual`
    - `v_demografia_resumen`
    - `v_gentrificacion_tendencias`
  - Las definiciones siguen el diseño documentado en `docs/spike/DATABASE_ARCHITECTURE_DESIGN.md`.

- **Integración en el pipeline ETL (`src/etl/pipeline.py`)**
  - Tras cargar `dim_barrios` en SQLite:
    - Llama a `migrate_dim_barrios_if_needed(conn)` con manejo de errores no bloqueante (log + continúa).
  - Tras cargar `fact_precios`, `fact_renta`, `fact_demografia`, `fact_oferta_idealista`:
    - Llama a `create_analytical_views(conn)` para garantizar que las vistas se creen/actualicen en cada ejecución.
  - Mantiene el comportamiento actual del ETL y respeta la integridad referencial.

- **Tests añadidos y actualizados**
  - `tests/test_dim_barrios_migration.py`
    - Tests unitarios para `calculate_centroid()` y `calculate_area_km2()` con polígonos en rango Barcelona.
    - Test de `get_ine_codes()` cuando el archivo de mapping no existe (devuelve `{}`).
    - Test de integración `migrate_dim_barrios_if_needed()` que valida centroides y área en rango razonable.
  - `tests/test_dim_tiempo.py`
    - Verifica creación y población de `dim_tiempo` (2015–2024, anual + trimestral).
    - Verifica idempotencia al llamar `create_database_schema()` múltiples veces.
  - `tests/test_database_views.py`
    - Verifica creación de las 4 vistas analíticas.
    - Verifica que `v_precios_evolucion_anual` devuelve datos agregados correctamente.
    - Verifica estructura y join de `v_demografia_resumen` incluyendo las nuevas columnas demográficas.
    - Verifica señal básica en `v_gentrificacion_tendencias` (cambio de precios entre 2015 y 2024).

### Cómo aplicar migraciones a una base existente

Para actualizar una base existente (por ejemplo `data/processed/database.db`) sin re-ejecutar todo el ETL:

python -c "from pathlib import Path; from src.database_setup import create_connection, create_database_schema; db = Path('data/processed/database.db'); conn = create_connection(db); create_database_schema(conn); conn.close()"Después de eso:
- `PRAGMA table_info(fact_demografia);` mostrará las columnas adicionales.
- `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dim_tiempo';` confirmará `dim_tiempo`.
- Las vistas se recrean automáticamente en la siguiente ejecución de `run_etl()`.

### Estado de tests y cobertura

- `./.venv-spike/bin/pytest` → **todos los tests pasan**.
- Nuevos tests para migraciones, `dim_tiempo` y vistas se ejecutan sin romper la suite existente.
`
bash
python -c "from pathlib import Path; from src.database_setup import create_connection, create_database_schema; db = Path('data/processed/database.db'); conn = create_connection(db); create_database_schema(conn); conn.close()"
.
`
Después de eso:- `PRAGMA table_info(fact_demografia);` mostrará las columnas adicionales.- `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'dim_tiempo';` confirmará `dim_tiempo`.- Las vistas se recrean automáticamente en la siguiente ejecución de `run_etl()`.### Estado de tests y cobertura- `./.venv-spike/bin/pytest` → **todos los tests pasan**.- Nuevos tests para migraciones, `dim_tiempo` y vistas se ejecutan sin romper la suite existente.